### PR TITLE
[SYS-3367] Adds documentation to runtime

### DIFF
--- a/runtime/README.md
+++ b/runtime/README.md
@@ -4,13 +4,13 @@ The avn-dev-runtime is a custom runtime that incorporates some of the AvN pallet
 ## Implementation Details
 
 The avn-dev-runtime includes core functionality of AvN, although certain pallets such as the summary pallet, have some of their functionality disabled.
-Any traits implemented from the missing pallets, that the runtime had a dependency to them have been emulated in [emulations.rs](src/emulations.rs)
+Any traits implemented from the missing pallets, on which the runtime depended, have been emulated in [emulations.rs](src/emulations.rs)
 ### Ethereum Bridge
-Currently, the ethereum bridge is disabled in this runtime. Both the ethereum-events and ethereum-transaction pallets are not included.
+Currently, the ethereum bridge is disabled in this runtime. Neither the ethereum-events and ethereum-transaction pallets are included.
 
 The runtime uses the default implementation of `ProcessedEventsChecker` interface, which always returns false when checking an event.
 
-The token and nft-manager pallets are typically subscribed to the ethereum-events `ProcessedEventHandler` implementation to process token lifts and NFT actions. Since the pallets are not subsribing to a handler, such actions won't be enabled either. A new handler can be implemented to simulate this behaviour and provide the node with events ready for processing.
+The token and nft-manager pallets are typically subscribed to the ethereum-events `ProcessedEventHandler` implementation to process token lifts and NFT actions. Since the pallets are not subscribing to a handler, such actions won't be enabled either. A new handler can be implemented to simulate this behaviour and provide the node with events ready for processing.
 
 ### On-Chain Finality Tracker
 


### PR DESCRIPTION
This commit adds minimal documentation to the runtime, providing an overview of the current state and highlighting some of the implementation shortcuts that were taken.

Related JIRA items:
- SYS-3367
